### PR TITLE
Extract important queries to postgres functions

### DIFF
--- a/hasql-queue.cabal
+++ b/hasql-queue.cabal
@@ -1,13 +1,13 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.31.2.
+-- This file has been generated from package.yaml by hpack version 0.34.4.
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 956ae93525f9dafcc0c9c8149cd2bbc8cfcfe4e63310adec92ce40f995e4cbf4
+-- hash: 30a78bb71c0fb6470ad0d6b6788b23f19801ab253d1c65e008a48e329e01b914
 
 name:           hasql-queue
-version:        1.2.0.1
+version:        1.3.0.0
 synopsis:       A PostgreSQL backed queue
 description:    A PostgreSQL backed queue. Please see README.md
 category:       Web
@@ -18,7 +18,8 @@ maintainer:     jonathangfischoff@gmail.com
 copyright:      2020 Jonathan Fischoff
 license:        BSD3
 license-file:   LICENSE
-tested-with:    GHC ==8.8.1
+tested-with:
+    GHC ==8.8.1
 build-type:     Simple
 extra-source-files:
     README.md
@@ -42,7 +43,16 @@ library
       Paths_hasql_queue
   hs-source-dirs:
       src
-  default-extensions: OverloadedStrings LambdaCase RecordWildCards TupleSections GeneralizedNewtypeDeriving QuasiQuotes ScopedTypeVariables TypeApplications AllowAmbiguousTypes
+  default-extensions:
+      OverloadedStrings
+      LambdaCase
+      RecordWildCards
+      TupleSections
+      GeneralizedNewtypeDeriving
+      QuasiQuotes
+      ScopedTypeVariables
+      TypeApplications
+      AllowAmbiguousTypes
   ghc-options: -Wall -Wno-unused-do-bind -Wno-unused-foralls
   build-depends:
       aeson
@@ -67,7 +77,16 @@ executable benchmark
       Paths_hasql_queue
   hs-source-dirs:
       benchmarks
-  default-extensions: OverloadedStrings LambdaCase RecordWildCards TupleSections GeneralizedNewtypeDeriving QuasiQuotes ScopedTypeVariables TypeApplications AllowAmbiguousTypes
+  default-extensions:
+      OverloadedStrings
+      LambdaCase
+      RecordWildCards
+      TupleSections
+      GeneralizedNewtypeDeriving
+      QuasiQuotes
+      ScopedTypeVariables
+      TypeApplications
+      AllowAmbiguousTypes
   ghc-options: -Wall -Wno-unused-do-bind -Wno-unused-foralls -O2 -threaded -rtsopts -with-rtsopts=-N
   build-depends:
       aeson
@@ -98,7 +117,16 @@ executable hasql-queue-tmp-db
       Paths_hasql_queue
   hs-source-dirs:
       hasql-queue-tmp-db
-  default-extensions: OverloadedStrings LambdaCase RecordWildCards TupleSections GeneralizedNewtypeDeriving QuasiQuotes ScopedTypeVariables TypeApplications AllowAmbiguousTypes
+  default-extensions:
+      OverloadedStrings
+      LambdaCase
+      RecordWildCards
+      TupleSections
+      GeneralizedNewtypeDeriving
+      QuasiQuotes
+      ScopedTypeVariables
+      TypeApplications
+      AllowAmbiguousTypes
   ghc-options: -Wall -Wno-unused-do-bind -Wno-unused-foralls -O2 -threaded -rtsopts -with-rtsopts=-N -g2
   build-depends:
       aeson
@@ -137,7 +165,16 @@ test-suite unit-tests
       Paths_hasql_queue
   hs-source-dirs:
       test
-  default-extensions: OverloadedStrings LambdaCase RecordWildCards TupleSections GeneralizedNewtypeDeriving QuasiQuotes ScopedTypeVariables TypeApplications AllowAmbiguousTypes
+  default-extensions:
+      OverloadedStrings
+      LambdaCase
+      RecordWildCards
+      TupleSections
+      GeneralizedNewtypeDeriving
+      QuasiQuotes
+      ScopedTypeVariables
+      TypeApplications
+      AllowAmbiguousTypes
   ghc-options: -Wall -Wno-unused-do-bind -Wno-unused-foralls -O2 -threaded -rtsopts -with-rtsopts=-N
   build-depends:
       aeson

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: hasql-queue
-version: '1.2.0.2'
+version: '1.3.0.0'
 synopsis: A PostgreSQL backed queue
 description: A PostgreSQL backed queue. Please see README.md
 category: Web

--- a/src/Hasql/Queue/High/ExactlyOnce.hs
+++ b/src/Hasql/Queue/High/ExactlyOnce.hs
@@ -58,30 +58,13 @@ dequeue valueDecoder count
   | count <= 0 = pure []
   | otherwise = do
   let multipleQuery = [here|
-        DELETE FROM payloads
-        WHERE id in
-          ( SELECT p1.id
-            FROM payloads AS p1
-            WHERE p1.state='enqueued'
-            ORDER BY p1.modified_at ASC
-            FOR UPDATE SKIP LOCKED
-            LIMIT $1
-          )
-        RETURNING value
+        SELECT value FROM dequeue_payload($1)
       |]
+
       multipleEncoder = E.param $ E.nonNullable $ fromIntegral >$< E.int4
 
       singleQuery = [here|
-        DELETE FROM payloads
-        WHERE id =
-          ( SELECT p1.id
-            FROM payloads AS p1
-            WHERE p1.state='enqueued'
-            ORDER BY p1.modified_at ASC
-            FOR UPDATE SKIP LOCKED
-            LIMIT 1
-          )
-        RETURNING value
+        SELECT value FROM dequeue_payload(1)
       |]
 
       singleEncoder = mempty

--- a/test/Hasql/Queue/Low/AtLeastOnceSpec.hs
+++ b/test/Hasql/Queue/Low/AtLeastOnceSpec.hs
@@ -142,8 +142,8 @@ spec = describe "Hasql.Queue.Low.AtLeastOnce" $ aroundAll withSetup $ describe "
     let Just decoded = mapM (decode . encode) xs
     sort decoded `shouldBe` sort expected
 
-  it "enqueue returns a PayloadId that cooresponds to the entry it added" $ withConnection $ \conn -> do
+  it "enqueue returns a PayloadId that corresponds to the entry it added" $ withConnection $ \conn -> do
     [payloadId] <- I.runThrow (I.enqueuePayload E.int4 [1]) conn
     Just actual <- getPayload conn D.int4 payloadId
 
-    pValue actual `shouldBe` 1
+    pId actual `shouldBe` payloadId


### PR DESCRIPTION
The motivating use case for extracting these functions is that it
gives more control to the developer using this package on how to
deploy this to their infrastructure.

For instance, some people may be interested in a different table
structure for `payloads`, like having it partitioned. With this
change, developers are free to change the implementation of the
postgres functions as they see fit as long as they implement an
equivalent logic and return the same types.